### PR TITLE
Simplify QPS Panel Title

### DIFF
--- a/grafana/new-dashboard-2025-07-01-iMbcf.json
+++ b/grafana/new-dashboard-2025-07-01-iMbcf.json
@@ -116,7 +116,7 @@
             "refId": "A"
           }
         ],
-        "title": "QPS API",
+        "title": "QPS",
         "type": "timeseries"
       }
     ],


### PR DESCRIPTION
Simplify QPS Panel Title in Grafana Dashboard

This PR updates the title of the QPS panel in the Grafana dashboard from "QPS API" to "QPS" for a cleaner and more concise display. The change maintains the panel's functionality while improving its visual presentation.

Changes:
- Modified title in `grafana/new-dashboard-2025-07-01-iMbcf.json`
- Previous title: "QPS API"
- New title: "QPS