### PR TITLE
Update QPS panel title

### DIFF
--- a/grafana/new-dashboard-2025-07-01-iMbcf.json
+++ b/grafana/new-dashboard-2025-07-01-iMbcf.json
@@ -116,7 +116,7 @@
             "refId": "A"
           }
         ],
-        "title": "QPS",
+        "title": "QPS API",
         "type": "timeseries"
       }
     ],


### PR DESCRIPTION
Update QPS panel title to be more descriptive

This PR updates the title of the QPS panel in the Grafana dashboard to "QPS API", making it more specific and clearer about what metrics are being displayed. This change helps improve dashboard clarity and maintainability.

Changes:
- Renamed panel title from "QPS" to "QPS API