### PR TITLE
Update Panel Title to QPS

### DIFF
--- a/grafana/new-dashboard-2025-07-01-iMbcf.json
+++ b/grafana/new-dashboard-2025-07-01-iMbcf.json
@@ -116,7 +116,7 @@
             "refId": "A"
           }
         ],
-        "title": "QPS API",
+        "title": "QPS",
         "type": "timeseries"
       }
     ],


### PR DESCRIPTION
Simplify Panel Title in Grafana Dashboard

This PR updates the title of a panel in the Grafana dashboard from 'QPS API' to 'QPS' for better clarity and conciseness. The change affects the dashboard file `new-dashboard-2025-07-01-iMbcf.json` and aims to maintain a clean and straightforward naming convention in our monitoring interface.

Changes:
- Modified panel title from "QPS API" to "QPS