### PR TITLE
Update time range to 3h

### DIFF
--- a/grafana/new-dashboard-2025-07-01-iMbcf.json
+++ b/grafana/new-dashboard-2025-07-01-iMbcf.json
@@ -127,7 +127,7 @@
       "list": []
     },
     "time": {
-      "from": "now-1h",
+      "from": "now-3h",
       "to": "now"
     },
     "timepicker": {},


### PR DESCRIPTION
Time Range Extension in Grafana Dashboard

This PR updates the default time range in the Grafana dashboard from 1 hour to 3 hours, providing a broader view of metrics by default. This change allows users to observe longer-term trends and patterns without manually adjusting the time range.

Changes:
- Modified time range from `now-1h` to `now-3h` in dashboard configuration