### PR TITLE
Update panel title to QPS

### DIFF
--- a/grafana/new-dashboard-2025-07-01-iMbcf.json
+++ b/grafana/new-dashboard-2025-07-01-iMbcf.json
@@ -116,7 +116,7 @@
             "refId": "A"
           }
         ],
-        "title": "QPS API",
+        "title": "QPS",
         "type": "timeseries"
       }
     ],


### PR DESCRIPTION
Simplify Panel Title in Grafana Dashboard

This PR updates the panel title in the Grafana dashboard from 'QPS API' to 'QPS', making it more concise while maintaining clarity. The change aims to improve dashboard readability by using a more straightforward title for the QPS metrics panel.

Changes:
- Modified panel title in `grafana/new-dashboard-2025-07-01-iMbcf.json`
- Simplified from "QPS API" to "QPS