### PR TITLE
Add QPS API panel

### DIFF
--- a/grafana/new-dashboard-2025-07-01-iMbcf.json
+++ b/grafana/new-dashboard-2025-07-01-iMbcf.json
@@ -116,7 +116,7 @@
             "refId": "A"
           }
         ],
-        "title": "QPS",
+        "title": "QPS API",
         "type": "timeseries"
       }
     ],


### PR DESCRIPTION
Add QPS API Panel to Dashboard

This PR updates the title of a time series panel from "QPS" to "QPS API" to better reflect its purpose in monitoring API query rates. The panel is configured with standard threshold settings to help track and visualize API performance metrics.

The change improves dashboard clarity by using more specific naming conventions for monitoring components.