### PR TITLE
Update panel title to QPS

### DIFF
--- a/grafana/new-dashboard-2025-07-01-iMbcf.json
+++ b/grafana/new-dashboard-2025-07-01-iMbcf.json
@@ -116,7 +116,7 @@
             "refId": "A"
           }
         ],
-        "title": "QPS API",
+        "title": "QPS",
         "type": "timeseries"
       }
     ],


### PR DESCRIPTION
Title Change: Simplify Panel Title in Dashboard

This PR updates the panel title in the Grafana dashboard from 'QPS API' to 'QPS', making it more concise and cleaner. The change affects the dashboard configuration file `new-dashboard-2025-07-01-iMbcf.json` and aims to improve dashboard readability.

Changes:
- Modified panel title from "QPS API" to "QPS"

This is a minor visual improvement that doesn't affect the dashboard's functionality.